### PR TITLE
Fix Issue#5

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -38,7 +38,6 @@ body{
 .main .header .header_right p {
     font-weight: 400;
     font-size: 20px;
-    font-family: PingFangSC-Regular, PingFang SC;
 }
 
 .main .header .header_right div {
@@ -58,7 +57,6 @@ body{
 
 .main .header .header_right .active p {
     font-weight: 600;
-    font-family: PingFangSC-Semibold, PingFang SC;
 }
 
 .datenLord {

--- a/css/main.css
+++ b/css/main.css
@@ -1,3 +1,6 @@
+*{
+    font-family: PingFangSC-Regular, PingFang SC, "微软雅黑", Tahoma, Helvetica, Arial, sans-serif;
+}
 @media only screen and (max-width: 1400px) {
     .main .jingyu {
         margin-top: 40px;
@@ -35,7 +38,6 @@
         width: auto;
         height: 16px;
         font-size: 16px;
-        font-family: PingFangSC-Regular, PingFang SC;
         font-weight: 400;
         line-height: 16px;
     }
@@ -118,13 +120,11 @@
         margin: 0;
         font-weight: 400;
         margin-bottom: 10px;
-        font-family: PingFangSC-Regular, PingFang SC;
     }
     .main .content_box_con {
         margin-bottom: 18px;
         font-size: 14px;
         padding: 0 10px;
-        font-family: PingFangSC-Regular, PingFang SC;
         font-weight: 400;
         color: #000000;
         line-height: 22px;
@@ -164,14 +164,12 @@
     }
     .content .recruit_Con_left p {
         font-size: 14px;
-        font-family: PingFangSC-Semibold, PingFang SC;
         color: #000000;
         line-height: 24px;
     }
 
     .content .recruit_Con_box h4 {
         font-size: 14px;
-        font-family: PingFangSC-Semibold, PingFang SC;
         color: #000000;
         font-weight: 600;
         line-height: 24px;

--- a/docs.html
+++ b/docs.html
@@ -9,9 +9,9 @@
   <meta name="keywords" content="DatenLord,文档,Docs,快速开始,Quick Start,架构,Architecture,DatenLord Optimization Strategy,Target Usage Scenarios,deploy DatenLord,use DatenLord,Road Map">
   <meta name="description" content="DatenLord文档页面，详细介绍了什么是DatenLord，为什么选择DatenLord，DatenLord的优化策略、使用场景，以及如何部署和使用DatenLord。">
   <link rel="icon" href="./images/favicon.ico" type="image/x-icon"/>
-  <link type="text/css" rel="styleSheet" href="./css/index.css?v=20211211" />
-  <link type="text/css" rel="styleSheet" href="./css/reset.css?v=20211211" />
-  <link type="text/css" rel="styleSheet" href="./css/main.css?v=20211211" />
+  <link type="text/css" rel="styleSheet" href="./css/index.css?v=20211214" />
+  <link type="text/css" rel="styleSheet" href="./css/reset.css?v=20211214" />
+  <link type="text/css" rel="styleSheet" href="./css/main.css?v=20211214" />
   <link rel="stylesheet" href="./css/vs2015.min.css">
   <script src="./js/jquery.js"></script>
   <script src="./js/highlight.js"></script>
@@ -869,7 +869,7 @@ kubectl apply -f datenlord-demo.yaml
 
     </div>
   </div>
-  <script type="text/javascript" src="./js/main.js?v=20211211"></script>
+  <script type="text/javascript" src="./js/main.js?v=20211214"></script>
   <script>isIE();</script>
 </body>
 

--- a/en/docs.html
+++ b/en/docs.html
@@ -9,9 +9,9 @@
   <meta name="keywords" content="DatenLord,Docs,Documentation,Quick Start,Architecture,DatenLord Optimization Strategy,Target Usage Scenarios,deploy DatenLord,use DatenLord,Road Map">
   <meta name="description" content="The DatenLord document page describes in detail what DatenLord is, why DatenLord is selected, the optimization strategy and usage scenario of DatenLord, and how to deploy and use DatenLord.">
   <link rel="icon" href="../images/favicon.ico" type="image/x-icon"/>
-  <link type="text/css" rel="styleSheet" href="../css/index.css?v=20211211" />
-  <link type="text/css" rel="styleSheet" href="../css/reset.css?v=20211211" />
-  <link type="text/css" rel="styleSheet" href="../css/main.css?v=20211211" />
+  <link type="text/css" rel="styleSheet" href="../css/index.css?v=20211214" />
+  <link type="text/css" rel="styleSheet" href="../css/reset.css?v=20211214" />
+  <link type="text/css" rel="styleSheet" href="../css/main.css?v=20211214" />
   <link rel="stylesheet" href="../css/vs2015.min.css">
   <script src="../js/jquery.js"></script>
   <script src="../js/highlight.js"></script>
@@ -869,7 +869,7 @@ kubectl apply -f datenlord-demo.yaml
 
     </div>
   </div>
-  <script type="text/javascript" src="../js/main.js?v=20211211"></script>
+  <script type="text/javascript" src="../js/main.js?v=20211214"></script>
   <script>isIE();</script>
 </body>
 

--- a/en/home.html
+++ b/en/home.html
@@ -8,10 +8,10 @@
     <meta name="keywords" content="DatenLord,cloud-native,distributed storage system,Across Multiple Could Providers,High Performance Cache,High Speed Network">
     <meta name="description" content="DatenLord is a new generation of cloud-native distributed storage system, which has the features of across multiple cloud providers, high-performance cache, high-speed network and distributed storage.">
     <link rel="icon" href="../images/favicon.ico" type="image/x-icon"/>
-    <link type="text/css" rel="styleSheet"  href="../css/index.css?v=20211211" />
-    <link type="text/css" rel="styleSheet"  href="../css/reset.css?v=20211211" />
-    <link type="text/css" rel="styleSheet"  href="../css/main.css?v=20211211" />
-    <link type="text/css" rel="styleSheet"  href="./mo_css/home.css?v=20211211" />
+    <link type="text/css" rel="styleSheet"  href="../css/index.css?v=20211214" />
+    <link type="text/css" rel="styleSheet"  href="../css/reset.css?v=20211214" />
+    <link type="text/css" rel="styleSheet"  href="../css/main.css?v=20211214" />
+    <link type="text/css" rel="styleSheet"  href="./mo_css/home.css?v=20211214" />
     <style>
         .content_box {
             width: 270px;
@@ -50,7 +50,6 @@
             margin-bottom: 88px;
             padding: 0 20px;
             font-size: 18px;
-            font-family: PingFangSC-Regular, PingFang SC;
             font-weight: 400;
             color: #000000;
             line-height: 26px;
@@ -72,9 +71,9 @@
             background-size: 100% 100%;
         }
 
-        .content_box:hover {
+        /* .content_box:hover {//暂时注释hover效果
             box-shadow: 0px 8px 20px 10px rgba(41, 93, 210, 0.6);
-        }
+        } */
     </style>
 </head>
 <body>
@@ -184,7 +183,7 @@
 
     </div>
 </div>
-<script type="text/javascript" src="../js/main.js?v=20211211"></script>
+<script type="text/javascript" src="../js/main.js?v=20211214"></script>
 <script>isIE();</script>
 </body>
 </html>

--- a/en/join.html
+++ b/en/join.html
@@ -9,10 +9,10 @@
     <meta name="keywords" content="Join us,DatenLord Jobs,RUST,FPGA,Development Engineer,Trainee,Telecommuting">
     <meta name="description" content="Datenlord recruitment. Telecommuting, unlimited location. We look forward to working with you to build a new generation of cloud native distributed storage system.">
     <link rel="icon" href="../images/favicon.ico" type="image/x-icon" />
-    <link type="text/css" rel="styleSheet" href="../css/index.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="../css/reset.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="../css/main.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="../css/join.css?v=20211211" />
+    <link type="text/css" rel="styleSheet" href="../css/index.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="../css/reset.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="../css/main.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="../css/join.css?v=20211214" />
 	<script src="../js/jquery.js"></script>
 </head>
 <body>
@@ -106,7 +106,7 @@
 
         </div>
     </div>
-    <script type="text/javascript" src="../js/main.js?v=202112111636"></script>
+    <script type="text/javascript" src="../js/main.js?v=202112141636"></script>
     <script>
         isIE();
         getJobList("../data/jobs_en.json"); 

--- a/en/mo_css/home.css
+++ b/en/mo_css/home.css
@@ -5,7 +5,6 @@
         display: flex;
         justify-content: center;
         font-size: 14px;
-        font-family: PingFangSC-Regular, PingFang SC;
         font-weight: 400;
         color: #000000;
         line-height: 20px;
@@ -18,7 +17,6 @@
         margin-bottom: 47px;
         padding: 0 10px;
         font-size: 14px;
-        font-family: PingFangSC-Regular, PingFang SC;
         font-weight: 400;
         color: #000000;
         line-height: 20px;

--- a/home.html
+++ b/home.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <title>DatenLord | 首页</title>
     <meta charset="UTF-8">
@@ -7,10 +8,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="keywords" content="DatenLord,云原生,跨云服务,高性能缓存,高速网络,分布式存储,存储系统">
     <meta name="description" content="DatenLord是新一代云原生分布式存储系统，具有跨云服务、高性能缓存、高速网络和分布式存储的特点。">
-    <link rel="icon" href="./images/favicon.ico" type="image/x-icon"/>
-    <link type="text/css" rel="styleSheet"  href="./css/index.css?v20211211" />
-    <link type="text/css" rel="styleSheet"  href="./css/reset.css?v20211211" />
-    <link type="text/css" rel="styleSheet"  href="./css/main.css?v20211211" />
+    <link rel="icon" href="./images/favicon.ico" type="image/x-icon" />
+    <link type="text/css" rel="styleSheet" href="./css/index.css?v20211211" />
+    <link type="text/css" rel="styleSheet" href="./css/reset.css?v20211211" />
+    <link type="text/css" rel="styleSheet" href="./css/main.css?v20211211" />
     <style>
         .content_box {
             width: 270px;
@@ -47,7 +48,6 @@
             margin-bottom: 88px;
             padding: 0 20px;
             font-size: 16px;
-            font-family: PingFangSC-Regular, PingFang SC;
             font-weight: 400;
             color: #000000;
             line-height: 32px;
@@ -69,119 +69,123 @@
             background-size: 100% 100%;
         }
 
-        .content_box:hover {
+        /* .content_box:hover {//暂时注释hover效果
             box-shadow: 0px 8px 20px 10px rgba(41, 93, 210, 0.6);
-        }
+        } */
     </style>
 </head>
-<body>
-<div class="main">
-    <div class="header_box">
-        <div class="header">
-            <div class="header_left">
-                <img src="images/daztenLord.png"  onclick="window.location.href='home.html'" class="datenLord">
-                <img src="images/datenLord_logo.png"  onclick="window.location.href='home.html'" class="datenLord_logo">
-            </div>
-            <div class="header_right">
-                <div class="div_hover">
-                    <p onclick="window.location.href='docs.html'">DOCS</p>
-                </div>
-                <div class="div_hover">
-                    <p onclick="window.location.href='join.html'">JOIN US</p>
-                </div>
-                <div class="lang_select">
-                    <p>中</p>
-                    <img src="./images/drop-down.png" class="header_arrow drop_down">
-                    <div id="lang" class="lang_box">
-                        <ul class="lang">
-                            <li>中</li>
-                            <li onclick="window.location.href='./en/home.html'">EN</li>
-                        </ul>
-                    </div>
-                </div>
-                <div class="github_icon">
-                    <img src="images/github_icon.png" onclick="window.open('https://github.com/datenlord/datenlord');">
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="content">
-        <div class="home_banner">
-        </div>
-        <div style="display: flex;justify-content: center;width: 100%">
-            <div class="content_body">
-                <div class="content_box">
-                    <div class="content_img">
-                        <img src="images/cloud.png" class="home_img"/>
-                    </div>
-                    <p class="content_box_title">跨云服务</p>
-                    <p class="content_box_con">使用S3存储协议实现跨云存储</p>
-                </div>
-                <div class="content_box">
-                    <div class="content_img">
-                        <img src="images/cache.png" class="home_img"/>
-                    </div>
-                    <p class="content_box_title">高性能缓存</p>
-                    <p class="content_box_con">使用内存对热点数据高速缓存</p>
-                </div>
-                <div class="content_box">
-                    <div class="content_img">
-                        <img src="images/network.png" class="home_img"/>
-                    </div>
-                    <p class="content_box_title">高速网络</p>
-                    <p class="content_box_con">使用RMDA增加网络吞吐降低网络延迟</p>
-                </div>
-                <div class="content_box">
-                    <div class="content_img">
-                        <img src="images/store.png" class="home_img"/>
-                    </div>
-                    <p class="content_box_title">分布式存储</p>
-                    <p class="content_box_con">使用EPaxos协议保证跨节点数据一致性</p>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="footer_box">
-        <div class="footer">
-            <div class="footer_img">
-                <img src="images/logo_Dark.png">
-            </div>
-            <div class="footer_icon">
-                <img src="images/icon5.png" onclick="window.open('https://github.com/datenlord/datenlord');">
-            </div>
-        </div>
-        <div class="copyright">版权所有 © DatenLord 2021。 保留一切权利。</div>
-    </div>
-</div>
-<div class="model_back" id="tipModel">
-    <div class="model">
-        <div style="width: auto; text-align: center;">
-            <img src="images/DatenLord_logo_2x.png" style="margin-top: 30px;width: 100px;height: 100px">
-            <h3 style="color: #000000;margin-bottom: 20px;;font-size: 24px;font-weight: bold">请升级浏览器版本</h3>
-            <p>您正在使用旧版本浏览器。请升级浏览器以获得更好的体验。</p>
-            <div style="display: inline-block; text-align: center;">
-                <div style="display: inline-block;margin: 20px 0 10px 0">
-                    <img src="images/chrome.png" style="width: 100px; height: 100px; margin: 10px;">
-                    <p>Chrome</p>
-                </div>
-                <div style="display: inline-block;margin: 20px 0 10px 0">
-                    <img src="images/firefox.png" style="width: 100px; height: 100px; margin: 10px;">
-                    <p>Firefox</p>
-                </div>
-                <div style="display: inline-block;margin: 20px 0 10px 0">
-                    <img src="images/safari.png" style="width: 100px; height: 100px; margin: 10px;">
-                    <p>Safari</p>
-                </div>
-                <div style="display: inline-block;margin: 20px 0 10px 0">
-                    <img src="images/edge.png" style="width: 100px; height: 100px; margin: 10px;">
-                    <p>Edge</p>
-                </div>
-            </div>
-        </div>
 
+<body>
+    <div class="main">
+        <div class="header_box">
+            <div class="header">
+                <div class="header_left">
+                    <img src="images/daztenLord.png" onclick="window.location.href='home.html'" class="datenLord">
+                    <img src="images/datenLord_logo.png" onclick="window.location.href='home.html'"
+                        class="datenLord_logo">
+                </div>
+                <div class="header_right">
+                    <div class="div_hover">
+                        <p onclick="window.location.href='docs.html'">DOCS</p>
+                    </div>
+                    <div class="div_hover">
+                        <p onclick="window.location.href='join.html'">JOIN US</p>
+                    </div>
+                    <div class="lang_select">
+                        <p>中</p>
+                        <img src="./images/drop-down.png" class="header_arrow drop_down">
+                        <div id="lang" class="lang_box">
+                            <ul class="lang">
+                                <li>中</li>
+                                <li onclick="window.location.href='./en/home.html'">EN</li>
+                            </ul>
+                        </div>
+                    </div>
+                    <div class="github_icon">
+                        <img src="images/github_icon.png"
+                            onclick="window.open('https://github.com/datenlord/datenlord');">
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="content">
+            <div class="home_banner">
+            </div>
+            <div style="display: flex;justify-content: center;width: 100%">
+                <div class="content_body">
+                    <div class="content_box">
+                        <div class="content_img">
+                            <img src="images/cloud.png" class="home_img" />
+                        </div>
+                        <p class="content_box_title">跨云服务</p>
+                        <p class="content_box_con">使用S3存储协议实现跨云存储</p>
+                    </div>
+                    <div class="content_box">
+                        <div class="content_img">
+                            <img src="images/cache.png" class="home_img" />
+                        </div>
+                        <p class="content_box_title">高性能缓存</p>
+                        <p class="content_box_con">使用内存对热点数据高速缓存</p>
+                    </div>
+                    <div class="content_box">
+                        <div class="content_img">
+                            <img src="images/network.png" class="home_img" />
+                        </div>
+                        <p class="content_box_title">高速网络</p>
+                        <p class="content_box_con">使用RMDA增加网络吞吐降低网络延迟</p>
+                    </div>
+                    <div class="content_box">
+                        <div class="content_img">
+                            <img src="images/store.png" class="home_img" />
+                        </div>
+                        <p class="content_box_title">分布式存储</p>
+                        <p class="content_box_con">使用EPaxos协议保证跨节点数据一致性</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="footer_box">
+            <div class="footer">
+                <div class="footer_img">
+                    <img src="images/logo_Dark.png">
+                </div>
+                <div class="footer_icon">
+                    <img src="images/icon5.png" onclick="window.open('https://github.com/datenlord/datenlord');">
+                </div>
+            </div>
+            <div class="copyright">版权所有 © DatenLord 2021。 保留一切权利。</div>
+        </div>
     </div>
-</div>
-<script type="text/javascript" src="./js/main.js?v=20211211"></script>
-<script>isIE();</script>
+    <div class="model_back" id="tipModel">
+        <div class="model">
+            <div style="width: auto; text-align: center;">
+                <img src="images/DatenLord_logo_2x.png" style="margin-top: 30px;width: 100px;height: 100px">
+                <h3 style="color: #000000;margin-bottom: 20px;;font-size: 24px;font-weight: bold">请升级浏览器版本</h3>
+                <p>您正在使用旧版本浏览器。请升级浏览器以获得更好的体验。</p>
+                <div style="display: inline-block; text-align: center;">
+                    <div style="display: inline-block;margin: 20px 0 10px 0">
+                        <img src="images/chrome.png" style="width: 100px; height: 100px; margin: 10px;">
+                        <p>Chrome</p>
+                    </div>
+                    <div style="display: inline-block;margin: 20px 0 10px 0">
+                        <img src="images/firefox.png" style="width: 100px; height: 100px; margin: 10px;">
+                        <p>Firefox</p>
+                    </div>
+                    <div style="display: inline-block;margin: 20px 0 10px 0">
+                        <img src="images/safari.png" style="width: 100px; height: 100px; margin: 10px;">
+                        <p>Safari</p>
+                    </div>
+                    <div style="display: inline-block;margin: 20px 0 10px 0">
+                        <img src="images/edge.png" style="width: 100px; height: 100px; margin: 10px;">
+                        <p>Edge</p>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+    <script type="text/javascript" src="./js/main.js?v=20211214"></script>
+    <script>isIE();</script>
 </body>
+
 </html>

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>Title</title>
     <script>
         function toHome() {
-            window.location.href="./home.html";
+            window.location.href="./en/home.html";
         }
         toHome();
     </script>

--- a/join.html
+++ b/join.html
@@ -9,10 +9,10 @@
     <meta name="keywords" content="加入我们,DatenLord招聘,RUST,FPGA,开发工程师,实习生,远程办公">
     <meta name="description" content="DatenLord招聘，多个岗位虚位以待。远程办公，地点不限。期待您一起建设新一代云原生分布式存储系统。">
     <link rel="icon" href="./images/favicon.ico" type="image/x-icon" />
-    <link type="text/css" rel="styleSheet" href="./css/index.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="./css/reset.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="./css/main.css?v=20211211" />
-    <link type="text/css" rel="styleSheet" href="./css/join.css?v=20211211" />
+    <link type="text/css" rel="styleSheet" href="./css/index.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="./css/reset.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="./css/main.css?v=20211214" />
+    <link type="text/css" rel="styleSheet" href="./css/join.css?v=20211214" />
 	<script src="./js/jquery.js"></script>
 </head>
 
@@ -107,7 +107,7 @@
 
         </div>
     </div>
-    <script type="text/javascript" src="./js/main.js?v=202112111636"></script>
+    <script type="text/javascript" src="./js/main.js?v=202112141636"></script>
     <script>
         isIE();
         getJobList("data/jobs_cn.json"); 


### PR DESCRIPTION
https://github.com/datenlord/datenlord.github.io/issues/5
1、域名默认跳转英文主页
2、FF、windows和IE浏览器下字体有差异，体验不好
3、首页特性模块需要去掉hover效果，以免误导是超链接
测试环境链接：
https://hanslibra.github.io/datenlord.github.io/